### PR TITLE
Adds support for rollback

### DIFF
--- a/server/lib/deploy.js
+++ b/server/lib/deploy.js
@@ -27,7 +27,9 @@ const trackProgress = (id, branch, repository, sha, user) => {
     rulesDeleted: 0,
     error: null,
     logs,
-    log
+    log,
+    updatedConnections : [],
+    deletedRules : []
   };
 };
 
@@ -54,7 +56,8 @@ export default (storageContext, id, branch, repository, sha, user) => {
         .then(() => auth0.updateDatabases(progress, context.client, context.databases))
         .then(() => auth0.deleteRules(progress, context.client, context.rules))
         .then(() => auth0.updateRules(progress, context.client, context.rules))
-        .then(() => progress.log('Done.'));
+        .then(() => progress.log('Done.'))
+        .catch((err) => auth0.rollbackProgress(progress,context.client,err))
     })
     .then(() => appendProgress(storageContext, progress))
     .then(() => pushToSlack(progress, `${config('WT_URL')}/login`))


### PR DESCRIPTION
This change fixes #3 although its is not the main goal of the change.

This PR adds support for rollback in case of failure during deployment. To achieve this the following changes are made:
- The initial state of connections are saved to `progress` after updating them with the scripts in the repository.
- The initial set of rules are stored in `progress` after deleting them. All rules are deleted to avoid conflicts in order and to simplify rollback.
- In case of any error during deployment all updated connections are reverted back to the original options.
- In case of any error during rule deployment all deployed rules are deleted and the previous rules are restored.

Although rules' id's are not maintained during deployments this approach provide consistency in that after a failed deployment.
