### PR TITLE
Remove null values from custom scripts

### DIFF
--- a/server/lib/auth0/connections.js
+++ b/server/lib/auth0/connections.js
@@ -32,11 +32,6 @@ const updateDatabase = (progress, client, connections, database) => {
   const options = connection.options || { };
   options.customScripts = { };
 
-  // Reset all scripts.
-  constants.DATABASE_SCRIPTS.forEach(script => {
-    options.customScripts[script] = null;
-  });
-
   // Set all custom scripts from GitHub.
   database.scripts.forEach((script) => {
     options.customScripts[script.stage] = script.contents;


### PR DESCRIPTION
Custom scripts with `null` values are causing problems in auth0-server, because it sends the scripts to webtask even if they are not used.

PATCH will delete custom scripts that are not present in the API call, so the `null` shouldn't be necessary.
