### PR TITLE
Allow for namespaced branch names

### DIFF
--- a/server/lib/middlewares/githubWebhook.js
+++ b/server/lib/middlewares/githubWebhook.js
@@ -7,12 +7,13 @@ const calculateSignature = (key, blob) =>
   `sha1=${crypto.createHmac('sha1', key).update(new Buffer(blob, 'utf-8')).digest('hex')}`;
 
 const parse = (headers, { ref = '', commits = [], head_commit = {}, repository = {}, sender = {} }) => { // eslint-disable-line camelcase
-  const refParts = ref.split('/');
+  // If the ref starts with "refs/heads/", strip it
+  const branch = ref.replace(/^refs\/heads\//i, '');
 
   return {
     id: headers['x-github-delivery'],
     event: headers['x-github-event'],
-    branch: refParts.length === 3 ? refParts[2] : '',
+    branch,
     commits,
     repository: repository.full_name,
     user: sender.login,

--- a/tests/server/githubWebhook.tests.js
+++ b/tests/server/githubWebhook.tests.js
@@ -59,6 +59,39 @@ describe('github Webhook', () => {
     });
   });
 
+  it('should update req.webhook with branch for ref of refs/heads/*', (done) => {
+    const webhook = githubWebhook('secret');
+    const req = {
+      headers: { 'x-github-delivery': 'id', 'x-github-event': 'event', 'x-hub-signature': 'sha1=091486123ad57d92919ee0d9d68444504eb7e2cd' },
+      body: {
+        ref: 'refs/heads/foo/bar'
+      },
+      rawBody: 'someRawBody'
+    };
+
+    webhook(req, {}, () => {
+      expect(req.webhook).toBeA(Object);
+      expect(req.webhook.branch).toEqual('foo/bar');
+      done();
+    });
+  });
+
+  it('should update req.webhook with branch for ref that does not start with refs/heads/', (done) => {
+    const webhook = githubWebhook('secret');
+    const req = {
+      headers: { 'x-github-delivery': 'id', 'x-github-event': 'event', 'x-hub-signature': 'sha1=091486123ad57d92919ee0d9d68444504eb7e2cd' },
+      body: {
+        ref: 'foo/bar'
+      },
+      rawBody: 'someRawBody'
+    };
+
+    webhook(req, {}, () => {
+      expect(req.webhook).toBeA(Object);
+      expect(req.webhook.branch).toEqual('foo/bar');
+      done();
+    });
+  });
 
   it('should work correctly with utf-8 characters in rawBody', (done) => {
     const webhook = githubWebhook('secret');


### PR DESCRIPTION
I ran into this when I tried to provide a namespaced git branch, e.g. `tenants/my-company`