### PR TITLE
KEY-639: connection prop reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Options reset on `databases` update issue. 
+
 ## [2.4.0] - 2018-11-29
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-github-deploy-extension",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Auth0 GitHub Deployment Extension",
   "engines": {
     "node": ">6"
@@ -29,7 +29,7 @@
     "externals": [
       "async@2.1.2",
       "auth0-extension-tools@1.3.2",
-      "auth0-source-control-extension-tools@3.0.9",
+      "auth0-source-control-extension-tools",
       "bluebird@3.4.6",
       "compression@1.4.4",
       "delegates@0.1.0",
@@ -77,7 +77,7 @@
     "auth0-extension-tools": "1.3.2",
     "auth0-extension-ui": "^1.0.1",
     "auth0-oauth2-express": "^1.1.8",
-    "auth0-source-control-extension-tools": "3.0.9",
+    "auth0-source-control-extension-tools": "3.0.10",
     "axios": "^0.15.0",
     "babel": "^6.5.2",
     "babel-core": "^6.9.1",

--- a/webtask.json
+++ b/webtask.json
@@ -1,8 +1,8 @@
 {
   "title": "GitHub Deployments",
   "name": "auth0-github-deploy",
-  "version": "2.4.0",
-  "preVersion": "2.3.4",
+  "version": "2.5.0",
+  "preVersion": "2.4.0",
   "author": "auth0",
   "description": "This extension gives Auth0 customers the possibility to deploy Pages, Rules and Custom Database Connections from GitHub.",
   "type": "application",


### PR DESCRIPTION
## ✏️ Changes
Actual fix is in [source-control-extension-tools PR](https://github.com/auth0-extensions/auth0-source-control-extension-tools/pull/51)
  
## 🔗 References
  Jira: https://auth0team.atlassian.net/browse/KEY-639
  
## 🎯 Testing
✅ This change has been tested locally

## 🚀 Deployment
⚠️ This should not be merged until [source-control-extension-tools PR](https://github.com/auth0-extensions/auth0-source-control-extension-tools/pull/51) merged, published to npm and added to the webtask.