### PR TITLE
Fixed database-scripts under non root BASE_DIR

### DIFF
--- a/server/lib/github.js
+++ b/server/lib/github.js
@@ -51,11 +51,11 @@ const isConfigurable = (file, directory) =>
  */
 const getDatabaseScriptDetails = (filename) => {
   const parts = filename.split('/');
-  if (parts.length === 3 && /\.js$/i.test(parts[2])) {
-    const scriptName = path.parse(parts[2]).name;
+  if (parts.length >= 3 && /\.js$/i.test(parts[parts.length - 1])) {
+    const scriptName = path.parse(parts[parts.length - 1]).name;
     if (constants.DATABASE_SCRIPTS.indexOf(scriptName) > -1) {
       return {
-        database: parts[1],
+        database: parts[parts.length - 2],
         name: path.parse(scriptName).name
       };
     }


### PR DESCRIPTION
## ✏️ Changes

The `getDatabaseScriptDetails` fn was hardcoded to only consider database scripts valid when placed in root folder and `BASE_DIR = '/'`. This has implications for multi-tenant repos where tenants need individual scripts, and all other files are deployed from a custom `BASE_DIR`. 

This fixes the check so that it's inline with expected behaviour when configuring `BASE_DIR`.
  
## 📷 Screenshots
 

## 🔗 References
  
## 🎯 Testing
  
  ```js
assert.deepStrictEqual(getDatabaseScriptDetails("/auth0/tenants/some_tenant/database-connections/Username-Password-Auth/login.js"), {
  database: 'Username-Password-Auth', name: 'login'
})
assert.deepStrictEqual(getDatabaseScriptDetails("/database-connections/Username-Password-Auth/login.js"), {
  database: 'Username-Password-Auth', name: 'login'
})
assert.deepStrictEqual(getDatabaseScriptDetails("/database-connections/Username-Password-Auth/INVALID.js"), null)
assert.deepStrictEqual(getDatabaseScriptDetails("Username-Password-Auth/login.js"), null)
```

🚫 This change has been tested in a Webtask
 
🚫 This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
✅ This can be deployed any time
  

## 🎡 Rollout
  
In order to verify that the deployment was successful,
* Create repo with database-scripts in a sub-path.
* Configure BASE_DIR property to the folder containing `database-scripts`
* Deploy repo to a tenant
* The database-scripts should be deployed correctly
  
## 🔥 Rollback
  
We will rollback if database scripts are no longer deployed correctly
  
### 📄 Procedure
  
Revert changes
 
## 🖥 Appliance
  
**Note to reviewers:** ensure that this change is compatible with the Appliance.
